### PR TITLE
Read passwords and license from env vars or terminal entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ to make a measurement.)
 dfxdemo org register <your_license_key>
 ```
 
+You can leave <your_license_key> blank to read it via the environment variable
+`DFXDEMO_LICENSE` or enter it securely in the terminal.
+
 **Note**: By default, the demo stores tokens in a file called `config.json`.
 *In a production application, you will need to manage all tokens securely.*
 
@@ -96,6 +99,9 @@ with a fixed Study ID.
 ```shell
 dfxdemo user login <email> <password>
 ```
+
+You can leave <password> blank to read it via the environment variable
+`DFXDEMO_PASSWORD` or enter it securely in the terminal.
 
 **Note**: All the commands below, use the tokens obtained above.
 

--- a/dfxdemo/dfxdemo.py
+++ b/dfxdemo/dfxdemo.py
@@ -658,10 +658,13 @@ async def login(config, email, password):
         print("Please register first to obtain a device_token")
         return False
 
+    pass_in_env = False
     if password is None:
         password = os.getenv("DFXDEMO_PASSWORD")
         if password is None:
             password = getpass.getpass()
+        else:
+            pass_in_env = True
 
     headers = {"Authorization": f"Bearer {dfxapi.Settings.device_token}"}
     async with aiohttp.ClientSession(headers=headers) as session:
@@ -674,6 +677,8 @@ async def login(config, email, password):
             return True
         else:
             print("Login failed")
+            if pass_in_env:
+                print(f"Ensure password in env:DFXDEMO_PASSWORD is for {email}")
             print(f"{status}: {body}")
             return False
 
@@ -702,10 +707,13 @@ async def org_login(config, email, password, org_key):
         print("Device is registered. Please unregister or use a different config file")
         return False
 
+    pass_in_env = False
     if password is None:
         password = os.getenv("DFXDEMO_ORGPASSWORD")
         if password is None:
             password = getpass.getpass()
+        else:
+            pass_in_env = True
 
     async with aiohttp.ClientSession() as session:
         status, body = await dfxapi.Organizations.login(session, email, password, org_key)
@@ -717,6 +725,8 @@ async def org_login(config, email, password, org_key):
             return True
         else:
             print("Login failed")
+            if pass_in_env:
+                print(f"Ensure password in env:DFXDEMO_ORGPASSWORD is for {email}")
             print(f"{status}: {body}")
             return False
 

--- a/dfxdemo/dfxdemo.py
+++ b/dfxdemo/dfxdemo.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import base64
 import copy
+import getpass
 import glob
 import json
 import math
@@ -585,6 +586,11 @@ async def register(config, license_key):
         print("Device already registered")
         return False
 
+    if license_key is None:
+        license_key = os.getenv("DFXDEMO_LICENSE")
+        if license_key is None:
+            license_key = getpass.getpass(prompt="DeepAffex License: ")
+
     try:
         async with aiohttp.ClientSession(raise_for_status=True) as session:
             await dfxapi.Organizations.register_license(session, license_key, "LINUX", "DFX Example", "DFXCLIENT",
@@ -652,6 +658,11 @@ async def login(config, email, password):
         print("Please register first to obtain a device_token")
         return False
 
+    if password is None:
+        password = os.getenv("DFXDEMO_PASSWORD")
+        if password is None:
+            password = getpass.getpass()
+
     headers = {"Authorization": f"Bearer {dfxapi.Settings.device_token}"}
     async with aiohttp.ClientSession(headers=headers) as session:
         status, body = await dfxapi.Users.login(session, email, password)
@@ -690,6 +701,11 @@ async def org_login(config, email, password, org_key):
     if dfxapi.Settings.device_token:
         print("Device is registered. Please unregister or use a different config file")
         return False
+
+    if password is None:
+        password = os.getenv("DFXDEMO_ORGPASSWORD")
+        if password is None:
+            password = getpass.getpass()
 
     async with aiohttp.ClientSession() as session:
         status, body = await dfxapi.Organizations.login(session, email, password, org_key)
@@ -955,13 +971,20 @@ def cmdline():
     subparser_orgs = subparser_top.add_parser("orgs", aliases=["o", "org"],
                                               help="Organizations").add_subparsers(dest="subcommand", required=True)
     register_parser = subparser_orgs.add_parser("register", help="Register device")
-    register_parser.add_argument("license_key", help="DFX API Organization License")
+    register_parser.add_argument(
+        "license_key",
+        help="DFX License (leave blank to read from env DFXDEMO_LICENSE or interactive entry)",
+        nargs="?",
+        default=None)
     register_parser.add_argument("--rest-url", help="Connect to DFX API using this REST URL", default=None)
     unregister_parser = subparser_orgs.add_parser("unregister", help="Unregister device")
-    o_login_parser = subparser_orgs.add_parser("login", help="Adminstrative login (no measurements)")
+    o_login_parser = subparser_orgs.add_parser("login", help="Administrative login (no measurements)")
     o_login_parser.add_argument("org_key", help="Organization Key")
     o_login_parser.add_argument("email", help="Email address")
-    o_login_parser.add_argument("password", help="Password")
+    o_login_parser.add_argument("password",
+                                help="Password (leave blank to read from env DFXDEMO_ORGPASSWORD or interactive entry)",
+                                nargs="?",
+                                default=None)
     o_list_parser = subparser_orgs.add_parser("list-measurements",
                                               aliases=[
                                                   "lm",
@@ -992,7 +1015,10 @@ def cmdline():
                                                help="Users").add_subparsers(dest="subcommand", required=True)
     login_parser = subparser_users.add_parser("login", help="User login")
     login_parser.add_argument("email", help="Email address")
-    login_parser.add_argument("password", help="Password")
+    login_parser.add_argument("password",
+                              help="Password (leave blank to read from env DFXDEMO_PASSWORD or interactive entry)",
+                              nargs="?",
+                              default=None)
     logout_parser = subparser_users.add_parser("logout", help="User logout")
 
     # profiles - create, update, remove, get, list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dfxdemo"
-version = "0.27.0"
+version = "0.28.0"
 description = "dfxdemo is a commandline demo for NuraLogix DeepAffex™ technologies."
+readme = "README.md"
+authors = [
+    { name = "NuraLogix Corporation" }
+]
+license = { file = "LICENSE.txt" }
 requires-python = ">=3.9"
 dependencies = [
     "dfx-apiv2-client>=0.15,<0.16",
@@ -28,6 +33,9 @@ visage = [
 [project.scripts]
 dfxdemo = "dfxdemo.dfxdemo:cmdline"
 dfxextract = "dfxdemo.dfxextract:cmdline"
+
+[project.urls]
+Homepage = "https://github.com/nuralogix/dfx-demo-py"
 
 [tool.setuptools]
 packages = ["dfxdemo", "dfxutils"]


### PR DESCRIPTION
When not passed via command line, read passwords and license from environment variables and if not present, then via interactive terminal entry.

Env vars:
DFXDEMO_LICENSE for org register,
DFXDEMO_PASSWORD for user login,
DFXDEMO_ORGPASSWORD for org login